### PR TITLE
bump to 0.3.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = 'jupyter_contrib_core' %}
-{% set version = '0.2.0' %}
-{% set md5 = 'e481a32a540f887353db88145eed0d2f' %}
+{% set version = '0.3.0' %}
+{% set md5 = 'cc53caaee0f2b0427189ed80bd86da8b' %}
 
 package:
   name: {{ name }}


### PR DESCRIPTION
Got here via this:
https://github.com/conda-forge/staged-recipes/pull/1159

Once I swam through all the issues in conda, it boiled down to `jupyter_contrib_nbextensions` needing this version! More coming... but this is pretty clutch...
